### PR TITLE
Removed all desktop.ini files

### DIFF
--- a/Ch04 Android Interface Design/MyContactList/.settings/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/.settings/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/assets/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/assets/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/bin/classes/com/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/bin/classes/com/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/bin/classes/com/example/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/bin/classes/com/example/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/bin/classes/com/example/mycontactlist/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/bin/classes/com/example/mycontactlist/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/bin/classes/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/bin/classes/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/bin/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/bin/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/bin/dexedLibs/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/bin/dexedLibs/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/bin/res/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/bin/res/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/bin/res/drawable-hdpi/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/bin/res/drawable-hdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/bin/res/drawable-mdpi/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/bin/res/drawable-mdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/bin/res/drawable-xhdpi/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/bin/res/drawable-xhdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/bin/res/drawable-xxhdpi/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/bin/res/drawable-xxhdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/gen/com/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/gen/com/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/gen/com/example/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/gen/com/example/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/gen/com/example/mycontactlist/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/gen/com/example/mycontactlist/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/gen/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/gen/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/libs/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/libs/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/res/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/res/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/res/drawable-hdpi/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/res/drawable-hdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/res/drawable-ldpi/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/res/drawable-ldpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/res/drawable-mdpi/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/res/drawable-mdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/res/drawable-xhdpi/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/res/drawable-xhdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/res/drawable-xxhdpi/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/res/drawable-xxhdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/res/layout/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/res/layout/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/res/menu/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/res/menu/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/res/values-sw600dp/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/res/values-sw600dp/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/res/values-sw720dp-land/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/res/values-sw720dp-land/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/res/values-v11/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/res/values-v11/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/res/values-v14/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/res/values-v14/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/res/values/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/res/values/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/src/com/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/src/com/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/src/com/example/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/src/com/example/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/src/com/example/mycontactlist/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/src/com/example/mycontactlist/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/MyContactList/src/desktop.ini
+++ b/Ch04 Android Interface Design/MyContactList/src/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch04 Android Interface Design/desktop.ini
+++ b/Ch04 Android Interface Design/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/.settings/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/.settings/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/assets/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/assets/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/bin/classes/com/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/bin/classes/com/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/bin/classes/com/example/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/bin/classes/com/example/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/bin/classes/com/example/mycontactlist/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/bin/classes/com/example/mycontactlist/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/bin/classes/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/bin/classes/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/bin/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/bin/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/bin/dexedLibs/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/bin/dexedLibs/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/bin/res/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/bin/res/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/bin/res/drawable-hdpi/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/bin/res/drawable-hdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/bin/res/drawable-mdpi/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/bin/res/drawable-mdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/bin/res/drawable-xhdpi/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/bin/res/drawable-xhdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/bin/res/drawable-xxhdpi/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/bin/res/drawable-xxhdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/gen/com/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/gen/com/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/gen/com/example/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/gen/com/example/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/gen/com/example/mycontactlist/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/gen/com/example/mycontactlist/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/gen/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/gen/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/libs/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/libs/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/res/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/res/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/res/drawable-hdpi/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/res/drawable-hdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/res/drawable-ldpi/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/res/drawable-ldpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/res/drawable-mdpi/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/res/drawable-mdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/res/drawable-xhdpi/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/res/drawable-xhdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/res/drawable-xxhdpi/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/res/drawable-xxhdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/res/layout/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/res/layout/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/res/menu/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/res/menu/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/res/values-sw600dp/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/res/values-sw600dp/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/res/values-sw720dp-land/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/res/values-sw720dp-land/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/res/values-v11/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/res/values-v11/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/res/values-v14/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/res/values-v14/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/res/values/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/res/values/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/src/com/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/src/com/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/src/com/example/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/src/com/example/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/src/com/example/mycontactlist/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/src/com/example/mycontactlist/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/MyContactList/src/desktop.ini
+++ b/Ch05 Android Persistent Data/MyContactList/src/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch05 Android Persistent Data/desktop.ini
+++ b/Ch05 Android Persistent Data/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/.settings/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/.settings/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/assets/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/assets/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/bin/classes/com/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/bin/classes/com/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/bin/classes/com/example/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/bin/classes/com/example/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/bin/classes/com/example/mycontactlist/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/bin/classes/com/example/mycontactlist/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/bin/classes/com/google/android/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/bin/classes/com/google/android/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/bin/classes/com/google/android/gms/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/bin/classes/com/google/android/gms/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/bin/classes/com/google/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/bin/classes/com/google/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/bin/classes/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/bin/classes/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/bin/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/bin/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/bin/dexedLibs/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/bin/dexedLibs/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/bin/res/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/bin/res/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/bin/res/drawable-hdpi/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/bin/res/drawable-hdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/bin/res/drawable-mdpi/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/bin/res/drawable-mdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/bin/res/drawable-xhdpi/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/bin/res/drawable-xhdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/bin/res/drawable-xxhdpi/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/bin/res/drawable-xxhdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/gen/com/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/gen/com/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/gen/com/example/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/gen/com/example/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/gen/com/example/mycontactlist/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/gen/com/example/mycontactlist/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/gen/com/google/android/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/gen/com/google/android/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/gen/com/google/android/gms/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/gen/com/google/android/gms/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/gen/com/google/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/gen/com/google/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/gen/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/gen/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/libs/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/libs/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/res/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/res/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/res/drawable-hdpi/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/res/drawable-hdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/res/drawable-ldpi/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/res/drawable-ldpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/res/drawable-mdpi/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/res/drawable-mdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/res/drawable-xhdpi/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/res/drawable-xhdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/res/drawable-xxhdpi/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/res/drawable-xxhdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/res/layout/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/res/layout/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/res/menu/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/res/menu/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/res/values-sw600dp/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/res/values-sw600dp/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/res/values-sw720dp-land/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/res/values-sw720dp-land/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/res/values-v11/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/res/values-v11/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/res/values-v14/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/res/values-v14/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/res/values/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/res/values/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/src/com/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/src/com/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/src/com/example/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/src/com/example/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/src/com/example/mycontactlist/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/src/com/example/mycontactlist/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/MyContactList/src/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/MyContactList/src/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/CompletedCode/desktop.ini
+++ b/Ch07 Android Location/CompletedCode/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/LocationFromAddress/desktop.ini
+++ b/Ch07 Android Location/LocationFromAddress/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/LocationFromMap/desktop.ini
+++ b/Ch07 Android Location/LocationFromMap/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/LocationFromSensors/desktop.ini
+++ b/Ch07 Android Location/LocationFromSensors/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch07 Android Location/desktop.ini
+++ b/Ch07 Android Location/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/.settings/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/.settings/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/assets/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/assets/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/bin/classes/com/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/bin/classes/com/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/bin/classes/com/example/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/bin/classes/com/example/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/bin/classes/com/example/mycontactlist/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/bin/classes/com/example/mycontactlist/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/bin/classes/com/google/android/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/bin/classes/com/google/android/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/bin/classes/com/google/android/gms/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/bin/classes/com/google/android/gms/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/bin/classes/com/google/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/bin/classes/com/google/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/bin/classes/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/bin/classes/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/bin/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/bin/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/bin/dexedLibs/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/bin/dexedLibs/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/bin/res/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/bin/res/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/bin/res/drawable-hdpi/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/bin/res/drawable-hdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/bin/res/drawable-mdpi/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/bin/res/drawable-mdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/bin/res/drawable-xhdpi/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/bin/res/drawable-xhdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/bin/res/drawable-xxhdpi/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/bin/res/drawable-xxhdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/gen/com/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/gen/com/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/gen/com/example/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/gen/com/example/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/gen/com/example/mycontactlist/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/gen/com/example/mycontactlist/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/gen/com/google/android/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/gen/com/google/android/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/gen/com/google/android/gms/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/gen/com/google/android/gms/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/gen/com/google/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/gen/com/google/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/gen/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/gen/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/libs/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/libs/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/res/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/res/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/res/drawable-hdpi/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/res/drawable-hdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/res/drawable-ldpi/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/res/drawable-ldpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/res/drawable-mdpi/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/res/drawable-mdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/res/drawable-xhdpi/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/res/drawable-xhdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/res/drawable-xxhdpi/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/res/drawable-xxhdpi/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/res/layout/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/res/layout/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/res/menu/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/res/menu/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/res/values-sw600dp/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/res/values-sw600dp/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/res/values-sw720dp-land/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/res/values-sw720dp-land/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/res/values-v11/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/res/values-v11/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/res/values-v14/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/res/values-v14/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/res/values/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/res/values/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/src/com/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/src/com/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/src/com/example/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/src/com/example/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/src/com/example/mycontactlist/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/src/com/example/mycontactlist/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/MyContactList/src/desktop.ini
+++ b/Ch08 Android Sensors/MyContactList/src/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    

--- a/Ch08 Android Sensors/desktop.ini
+++ b/Ch08 Android Sensors/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=12
-    


### PR DESCRIPTION
These files caused Eclipse to croak on OSX. Maybe on Windows it is clever enough to not import the files into a project, but on OSX it broke bad.
